### PR TITLE
Removes misleading component name in index.js

### DIFF
--- a/lib/generators/react_webpack_rails/templates/react/index.js.erb
+++ b/lib/generators/react_webpack_rails/templates/react/index.js.erb
@@ -2,9 +2,9 @@ import React from 'react';
 window.React = React;
 <% if options.example %>
 import HelloWorld from './components/hello-world';
-registerComponent('hello-world', HelloWorld);
+registerComponent('HelloWorld', HelloWorld);
 <% else %>
 // example usage:
 // import HelloWorld from './components/hello-world';
-// registerComponent('hello-world', HelloWorld);
+// registerComponent('HelloWorld', HelloWorld);
 <% end %>


### PR DESCRIPTION
I got mislead by the registerComponent line `registerComponent('hello-world', HelloWorld);` I thought that we were using `hello-world` because of the filename, and that the second argument was actually the name to be used when rendering.

I think you did this to demonstrate that the name could be different from the component class name (`HelloWorld`), but since we generally use the same name everywhere and I've been mislead, I think it wouldn't hurt to just make it the same everywher.

What do you think ?