### PR TITLE
Added webpack installation step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Establish the node packages (may take a few moments)
 
     $ npm install    # you may see warnings to consider updating the provided package.json file with license and repository
 
-If you don't have it, install webpack (see full description at: [webpack](https://webpack.github.io/docs/installation.html))
+Make sure you have [webpack](https://webpack.github.io/docs/installation.html) installed globally:
 
     $ npm install webpack -g
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Establish the node packages (may take a few moments)
 
     $ npm install    # you may see warnings to consider updating the provided package.json file with license and repository
 
+If you don't have it, install webpack (see full description at: [webpack](https://webpack.github.io/docs/installation.html))
+
+    $ npm install webpack -g
+
 Generate `react_bundle` for first time:
 
     $ webpack


### PR DESCRIPTION
adding this installation step will eliminate possible confusion for gem users -> they won't miss installing webpack during initial setup