### PR TITLE
add mocha and sinon packages to package.json

### DIFF
--- a/lib/generators/react_webpack_rails/templates/package.json.erb
+++ b/lib/generators/react_webpack_rails/templates/package.json.erb
@@ -11,6 +11,8 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",
+    "mocha": "^2.3.4",
+    "sinon": "^1.17.2",
     "react-hot-loader": "^1.3.0",
     "webpack-dev-server": "^1.12.1",
     "webpack-notifier": "^1.2.1"

--- a/spec/rails3_dummy_app/package.json
+++ b/spec/rails3_dummy_app/package.json
@@ -11,6 +11,8 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",
+    "mocha": "^2.3.4",
+    "sinon": "^1.17.2",
     "react-hot-loader": "^1.3.0",
     "webpack-dev-server": "^1.12.1",
     "webpack-notifier": "^1.2.1"

--- a/spec/rails4_dummy_app/package.json
+++ b/spec/rails4_dummy_app/package.json
@@ -11,6 +11,8 @@
     "karma-sinon": "^1.0.4",
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",
+    "mocha": "^2.3.4",
+    "sinon": "^1.17.2",
     "react-hot-loader": "^1.3.0",
     "webpack-dev-server": "^1.12.1",
     "webpack-notifier": "^1.2.1"


### PR DESCRIPTION
When I run `npm test` in a project where I've just installed the gem, it raises
```
❯ npm test

> SomeSuperSecretProject@ test /Users/m/work/ng/suchsecretwow
> karma start

module.js:340
    throw err;
    ^

Error: Cannot find module 'mocha'
```

That won't happen if you have mocha and sinon installed globally, but it's probably a good idea to add them to the `devDependencies`.
