### PR TITLE
update bin setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,5 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 bundle install
+cd spec/rails3_dummy_app && bundle install && cd ..
+cd rails4_dummy_app && bundle install
 
 # Do any other automated setup that you need to do here


### PR DESCRIPTION
When you run `bin/setup` and `rake` - the app might crash if you lack the dependencies of the dummy apps. To avoid this, we can bundle install each dummy app separately.