### PR TITLE
Redux integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.0.6
+* Add redux integration:
+  * js helpers:
+    * `registerStore`
+    * `registerContainer`
+    * `getStore`
+    * `renderContainer`
+  * rails helpers:
+    * `redux_store`
+    * `redux_container`
+
 ## 0.0.5 (November 26, 2015)
 * Add Hot Reload support
   * Dependencies:

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,7 @@
   * #### createComponent [js]
 
     ```js
-    createComponent(String componentName[, Object props])
+    createComponent(String componentName, [Object props])
     ```
 
     Wrapper over React.createElement that creates ready to render component with props.
@@ -153,3 +153,159 @@
     ```ruby
     <%= react_router('MyRouterName') %>
     ```
+
+## Redux
+
+  * #### registerContainer [js]
+    ```js
+    registerContainer(String containerName, class|function container)
+    ```
+
+    Register container so it's globally accessible.
+
+    ##### example:
+
+    ```js
+    import MyContainer from 'my-container';
+
+    registerContainer('MyContainerName', MyContainer);
+    ```
+
+    **note:** Registered containers are accessible in globally exposed `RWR.redux` under `containers` property.
+
+  * #### getContainer [js]
+
+    ```js
+    getContainer(String containerName)
+    ```
+
+    Shortcut for accessing registered container.
+
+    ##### example:
+
+    ```js
+    getContainer('MyContainertName');
+    ```
+
+  * #### createContainer [js]
+
+    ```js
+    createContainer(String containerName, [Object props])
+    ```
+
+    Wrapper over React.createElement that creates ready to render container with props.
+
+    ##### example:
+
+    ```js
+    createContainer('MyContainerName', {foo: 'bar'});
+    ```
+
+  * #### renderContainer [js]
+
+    ```js
+    renderContainer(String containerName, Object props, DOMElement container)
+    ```
+
+    Wrapper over `React.render` and `React.createElement`. Renders container with given props into specified DOM element.
+
+    ##### example:
+
+    ```js
+    var element = document.getElementById('my-element');
+    renderContainer('MyContainerName', {foo: 'bar'}, element);
+    ```
+
+  * #### unmountContainer [js]
+
+    ```js
+    unmountContainer(DOMElement container)
+    ```
+
+    Wrapper over `React.unmountContainerAtNode`. It will unmount container from given DOM node.
+
+    ##### example:
+
+    ```js
+    var element = document.getElementById('my-element');
+    unmountContainer(element);
+    ```
+
+  * ### redux_container [ruby]
+
+    ```ruby
+    redux_container(String container_name)
+    ```
+
+    Creates DOM node with initial state from Store as data attributes in rendered view so RWR can grab it and mount proper container.
+
+    ##### example:
+
+    ```ruby
+    <%= redux_container('MyComponentName') %>
+    ```
+
+  * #### registerStore [js]
+    ```js
+    registerStore(String storeName, class|function store)
+    ```
+
+    Register store so it's globally accessible.
+
+    ##### example:
+
+    ```js
+    import Store from './store/store';
+
+    registerStore('StoreName', Store);
+    ```
+
+    **note:** Registered stores are accessible in globally exposed `RWR.redux` under `runningStores` property.
+
+  * #### mountStore [js]
+
+    ```js
+    mountStore(String storeName, [object props])
+    ```
+
+  * #### getStore [js]
+
+    ```js
+    getStore(String storeName)
+    ```
+
+    Shortcut for accessing registered store.
+
+    ##### example:
+
+    ```js
+    getStore('StoretName');
+    ```
+
+  * #### renderDevtools [js]
+
+    ```js
+    renderDevtools(String storeName, Object props, DOMElement container)
+    ```
+
+    Wrapper over `React.render` and `React.createElement`. Renders redux devtools with given props into specified DOM element.
+
+    ##### example:
+
+    ```js
+    var element = document.getElementById('my-element');
+    renderDevtools('StoreName', {foo: 'bar'}, element);
+    ```
+
+  * ### redux_store [ruby]
+
+    ```ruby
+    redux_store(String store_name, object initialState, object options)
+    ```
+
+    Mounts store and optional renders devtools.
+
+    ##### example:
+
+    ```ruby
+    <%= redux_store('StoreName', { counter: 3 }, { include_dev_tools: true, enable_devtools: true }) %>

--- a/lib/assets/javascripts/react_webpack_rails/redux_integration.js
+++ b/lib/assets/javascripts/react_webpack_rails/redux_integration.js
@@ -63,7 +63,7 @@ RWR.unmountContainer = RWR.redux.unmountContainer;
 RWR.integrations['redux-store'] = {
   mount: function _mountStoreWrapper (config, options) {
     RWR.mountStore(options.name, config.payload)
-    if (options.include_dev_tools != false) {
+    if (options.include_devtools === undefined || options.include_devtools === true) {
       RWR.renderDevtools(options.name, options, config.node)
     }
   },

--- a/lib/assets/javascripts/react_webpack_rails/redux_integration.js
+++ b/lib/assets/javascripts/react_webpack_rails/redux_integration.js
@@ -4,14 +4,25 @@ function registerStore(name, store) {
   RWR.redux.runningStores[name] = store;
 }
 
+function mountStore(name, props) {
+  new (getStore(name))(props)
+}
+
 function getStore(name) {
   return RWR.redux.runningStores[name];
+}
+
+function renderDevtools(node) {
+  var store = (new (getStore('Store'))).store
+  var devtools = React.createElement(DevTools, {store: store, monitor: LogMonitor});
+  var container = React.createElement(DebugPanel, {top: true, bottom: true, right: true, children: devtools});
+  RWR.reactDOM().render(container, node);
 }
 
 function renderContainer (name, props, node) {
   var store = (new (getStore('Store'))).store
   var component = RWR.react.createComponent(name, props);
-  container = React.createElement(Provider, {store: store, children: component});
+  var container = React.createElement(Provider, {store: store, children: component});
   RWR.reactDOM().render(container, node);
 }
 
@@ -28,7 +39,10 @@ function _unmountContainerWrapper(config) {
 }
 
 function _mountStoreWrapper (config, options) {
-  new (getStore(options.name))(config.payload)
+  mountStore(options.name, config.payload)
+  if (options.devtools != false) {
+    renderDevtools(config.node)
+  }
 }
 
 RWR.redux = {

--- a/lib/assets/javascripts/react_webpack_rails/redux_integration.js
+++ b/lib/assets/javascripts/react_webpack_rails/redux_integration.js
@@ -1,81 +1,124 @@
 //= require react_webpack_rails/globals
 
-function registerContainer(name, container) {
-  RWR.redux.containers[name] = container;
-}
-
-function registerStore(name, store) {
-  RWR.redux.runningStores[name] = store;
-}
-
-function mountStore(name, props) {
-  new (getStore(name))(props)
-}
-
-function getStore(name) {
-  return RWR.redux.runningStores[name];
-}
-
-function renderDevtools(name, props, node) {
-  var store = (new (getStore(name))).store
-  var visibleOnLoad = (typeof props.enable_devtools === 'undefined') ? true : props.enable_devtools
-  var devtools = React.createElement(DevTools, {store: store, monitor: LogMonitor, visibleOnLoad: visibleOnLoad});
-  var container = React.createElement(DebugPanel, {top: true, bottom: true, right: true, children: devtools});
-  RWR.reactDOM().render(container, node);
-}
-
-function getContainer(name) {
-  return RWR.redux.containers[name];
-}
-
-function createContainer(name, props) {
-  var constructor = getContainer(name);
-  return React.createElement(constructor, props);
-}
-
-function renderContainer (name, props, node) {
-  var storeName = Object.keys(RWR.redux.runningStores)[0]
-  var store = (new (getStore(storeName))).store
-  var component = createContainer(name, props);
-  var container = React.createElement(Provider, {store: store, children: component});
-  RWR.reactDOM().render(container, node);
-}
-
-function unmountContainer(node) {
-  RWR.reactDOM().unmountComponentAtNode(node);
-}
-
-function _renderContainerWrapper (config, options) {
-  renderContainer(options.name, config.payload, config.node)
-}
-
-function _unmountContainerWrapper(config) {
-  unmountContainer(config.node);
-}
-
-function _mountStoreWrapper (config, options) {
-  mountStore(options.name, config.payload)
-  if (options.include_dev_tools != false) {
-    renderDevtools(options.name, options, config.node)
-  }
-}
-
 RWR.redux = {
   runningStores: {},
   containers: {},
-  registerStore: registerStore,
-  registerContainer: registerContainer,
-  getContainer: getContainer,
-  getStore: getStore,
-  createContainer: createContainer,
-  renderContainer: renderContainer,
-};
+
+  registerContainer: function _registerContainer(name, container) {
+    RWR.redux.containers[name] = container;
+  },
+
+  registerStore: function _registerStore(name, store) {
+    RWR.redux.runningStores[name] = store;
+  },
+
+  mountStore: function _mountStore(name, props) {
+    new (RWR.getStore(name))(props);
+  },
+
+  getStore: function _getStore(name) {
+    return RWR.redux.runningStores[name];
+  },
+
+  getContainer: function _getContainer(name) {
+    return RWR.redux.containers[name];
+  },
+
+  renderDevtools: function _renderDevtools(name, props, node) {
+    var store = (new (RWR.getStore(name))).store;
+    var visibleOnLoad = (typeof props.enable_devtools === 'undefined') ? true : props.enable_devtools;
+    var devtools = React.createElement(DevTools, {store: store, monitor: LogMonitor, visibleOnLoad: visibleOnLoad});
+    var container = React.createElement(DebugPanel, {top: true, bottom: true, right: true, children: devtools});
+    RWR.reactDOM().render(container, node);
+  },
+
+  createContainer: function _createContainer(name, props) {
+    var constructor = RWR.getContainer(name);
+    return React.createElement(constructor, props);
+  },
+
+  renderContainer: function _renderContainer (name, props, node) {
+    var storeName = Object.keys(RWR.redux.runningStores)[0];
+    var store = (new (RWR.getStore(storeName))).store;
+    var component = RWR.createContainer(name, props);
+    var container = React.createElement(Provider, {store: store, children: component});
+    RWR.reactDOM().render(container, node);
+  },
+
+  unmountContainer: function _unmountContainer(node) {
+    RWR.reactDOM().unmountComponentAtNode(node);
+  },
+}
+
+RWR.registerStore = RWR.redux.registerStore;
+RWR.registerContainer = RWR.redux.registerContainer;
+RWR.mountStore = RWR.redux.mountStore;
+RWR.getContainer = RWR.redux.getContainer;
+RWR.getStore = RWR.redux.getStore;
+RWR.createContainer = RWR.redux.createContainer;
+RWR.renderContainer = RWR.redux.renderContainer;
+RWR.renderDevtools = RWR.redux.renderDevtools;
+RWR.unmountContainer = RWR.redux.unmountContainer;
 
 RWR.integrations['redux-store'] = {
-  mount: _mountStoreWrapper,
+  mount: function _mountStoreWrapper (config, options) {
+    RWR.mountStore(options.name, config.payload)
+    if (options.include_dev_tools != false) {
+      RWR.renderDevtools(options.name, options, config.node)
+    }
+  },
 };
 
 RWR.integrations['redux-container'] = {
-  mount: _renderContainerWrapper,
-  unmount: _unmountContainerWrapper,
+  mount: function _renderContainerWrapper (config, options) {
+    RWR.renderContainer(options.name, config.payload, config.node)
+  },
+
+  unmount: function _unmountContainerWrapper(config) {
+    RWR.unmountContainer(config.node);
+  },
 };
+
+function _depricatedReactHelperWarn(helperName) {
+  console.warn(RWR._messages.warnings.deprication(helperName, 'Use RWR.' + helperName + ' instead.'));
+}
+
+function registerStore() {
+  _depricatedReactHelperWarn('registerStore');
+  RWR.registerStore.apply(null, arguments);
+}
+
+function registerContainer() {
+  _depricatedReactHelperWarn('registerContainer');
+  RWR.registerContainer.apply(null, arguments);
+}
+
+function getContainer() {
+  _depricatedReactHelperWarn('getContainer');
+  RWR.getContainer.apply(null, arguments);
+}
+
+function getStore() {
+  _depricatedReactHelperWarn('getStore');
+  RWR.getStore.apply(null, arguments);
+}
+
+function createContainer() {
+  _depricatedReactHelperWarn('createContainer');
+  RWR.createContainer.apply(null, arguments);
+}
+
+function renderContainer() {
+  _depricatedReactHelperWarn('renderContainer');
+  RWR.renderContainer.apply(null, arguments);
+}
+
+function renderDevtools() {
+  _depricatedReactHelperWarn('renderDevtools');
+  RWR.renderDevtools.apply(null, arguments);
+}
+
+function unmountContainer() {
+  _depricatedReactHelperWarn('unmountContainer');
+  RWR.unmountContainer.apply(null, arguments);
+}

--- a/lib/assets/javascripts/react_webpack_rails/redux_integration.js
+++ b/lib/assets/javascripts/react_webpack_rails/redux_integration.js
@@ -1,0 +1,50 @@
+//= require react_webpack_rails/globals
+
+function registerStore(name, store) {
+  RWR.redux.runningStores[name] = store;
+}
+
+function getStore(name) {
+  return RWR.redux.runningStores[name];
+}
+
+RWR.redux = {
+  runningStores: {},
+  registerStore: registerStore,
+  getStore: getStore,
+};
+
+function renderContainer (name, props, node) {
+  var store = new (getStore('Store')).store
+  var component = RWR.react.createComponent(name, props);
+  container = React.createElement(Provider, {store: store, children: component}); //-> 2x uruchomić -
+  RWR.reactDOM().render(container, node);
+}
+
+function _renderContainerWrapper (config, options) {
+  renderContainer(options.name, config.payload, config.node)
+}
+
+function _unmountContainerWrapper (config, options) {
+  debugger;
+}
+
+function _mountStoreWrapper (config, options) {
+  // debugger;
+  // var store = RWR.react.createComponent(options.name, config.payload);
+  // RWR.reactDOM().render(store, config.node);
+  // createStore(options.name, config.payload, config.node)
+  // debugger; wyciągnąć nazwę stora i initial state componentu (z payload, options itp) -> globalny provider -> sprawdzić
+  // przypisać do RWR.runningStores ->
+  new (getStore('Store'))(config.payload)
+}
+
+
+RWR.integrations['redux-store'] = {
+  mount: _mountStoreWrapper,
+};
+
+RWR.integrations['redux-container'] = {
+  mount: _renderContainerWrapper,
+  unmount: _unmountContainerWrapper,
+};

--- a/lib/assets/javascripts/react_webpack_rails/redux_integration.js
+++ b/lib/assets/javascripts/react_webpack_rails/redux_integration.js
@@ -8,37 +8,35 @@ function getStore(name) {
   return RWR.redux.runningStores[name];
 }
 
-RWR.redux = {
-  runningStores: {},
-  registerStore: registerStore,
-  getStore: getStore,
-};
-
 function renderContainer (name, props, node) {
-  var store = new (getStore('Store')).store
+  var store = (new (getStore('Store'))).store
   var component = RWR.react.createComponent(name, props);
-  container = React.createElement(Provider, {store: store, children: component}); //-> 2x uruchomić -
+  container = React.createElement(Provider, {store: store, children: component});
   RWR.reactDOM().render(container, node);
+}
+
+function unmountContainer(node) {
+  RWR.reactDOM().unmountComponentAtNode(node);
 }
 
 function _renderContainerWrapper (config, options) {
   renderContainer(options.name, config.payload, config.node)
 }
 
-function _unmountContainerWrapper (config, options) {
-  debugger;
+function _unmountContainerWrapper(config) {
+  unmountContainer(config.node);
 }
 
 function _mountStoreWrapper (config, options) {
-  // debugger;
-  // var store = RWR.react.createComponent(options.name, config.payload);
-  // RWR.reactDOM().render(store, config.node);
-  // createStore(options.name, config.payload, config.node)
-  // debugger; wyciągnąć nazwę stora i initial state componentu (z payload, options itp) -> globalny provider -> sprawdzić
-  // przypisać do RWR.runningStores ->
-  new (getStore('Store'))(config.payload)
+  new (getStore(options.name))(config.payload)
 }
 
+RWR.redux = {
+  runningStores: {},
+  registerStore: registerStore,
+  getStore: getStore,
+  renderContainer: renderContainer,
+};
 
 RWR.integrations['redux-store'] = {
   mount: _mountStoreWrapper,

--- a/lib/assets/javascripts/react_webpack_rails/redux_integration.js
+++ b/lib/assets/javascripts/react_webpack_rails/redux_integration.js
@@ -27,8 +27,8 @@ RWR.redux = {
   renderDevtools: function _renderDevtools(name, props, node) {
     var store = (new (RWR.getStore(name))).store;
     var visibleOnLoad = (typeof props.enable_devtools === 'undefined') ? true : props.enable_devtools;
-    var devtools = React.createElement(DevTools, {store: store, monitor: LogMonitor, visibleOnLoad: visibleOnLoad});
-    var container = React.createElement(DebugPanel, {top: true, bottom: true, right: true, children: devtools});
+    var devtools = RWR.createContainer('DevTools');
+    var container = React.createElement(Provider, {store: store, children: devtools});
     RWR.reactDOM().render(container, node);
   },
 

--- a/lib/assets/javascripts/react_webpack_rails/redux_integration.js
+++ b/lib/assets/javascripts/react_webpack_rails/redux_integration.js
@@ -1,5 +1,9 @@
 //= require react_webpack_rails/globals
 
+function registerContainer(name, container) {
+  RWR.redux.containers[name] = container;
+}
+
 function registerStore(name, store) {
   RWR.redux.runningStores[name] = store;
 }
@@ -20,10 +24,19 @@ function renderDevtools(name, props, node) {
   RWR.reactDOM().render(container, node);
 }
 
+function getContainer(name) {
+  return RWR.redux.containers[name];
+}
+
+function createContainer(name, props) {
+  var constructor = getContainer(name);
+  return React.createElement(constructor, props);
+}
+
 function renderContainer (name, props, node) {
   var storeName = Object.keys(RWR.redux.runningStores)[0]
   var store = (new (getStore(storeName))).store
-  var component = RWR.react.createComponent(name, props);
+  var component = createContainer(name, props);
   var container = React.createElement(Provider, {store: store, children: component});
   RWR.reactDOM().render(container, node);
 }
@@ -49,8 +62,12 @@ function _mountStoreWrapper (config, options) {
 
 RWR.redux = {
   runningStores: {},
+  containers: {},
   registerStore: registerStore,
+  registerContainer: registerContainer,
+  getContainer: getContainer,
   getStore: getStore,
+  createContainer: createContainer,
   renderContainer: renderContainer,
 };
 

--- a/lib/assets/javascripts/react_webpack_rails/redux_integration.js
+++ b/lib/assets/javascripts/react_webpack_rails/redux_integration.js
@@ -12,15 +12,17 @@ function getStore(name) {
   return RWR.redux.runningStores[name];
 }
 
-function renderDevtools(node) {
-  var store = (new (getStore('Store'))).store
-  var devtools = React.createElement(DevTools, {store: store, monitor: LogMonitor});
+function renderDevtools(name, props, node) {
+  var store = (new (getStore(name))).store
+  var visibleOnLoad = (typeof props.enable_devtools === 'undefined') ? true : props.enable_devtools
+  var devtools = React.createElement(DevTools, {store: store, monitor: LogMonitor, visibleOnLoad: visibleOnLoad});
   var container = React.createElement(DebugPanel, {top: true, bottom: true, right: true, children: devtools});
   RWR.reactDOM().render(container, node);
 }
 
 function renderContainer (name, props, node) {
-  var store = (new (getStore('Store'))).store
+  var storeName = Object.keys(RWR.redux.runningStores)[0]
+  var store = (new (getStore(storeName))).store
   var component = RWR.react.createComponent(name, props);
   var container = React.createElement(Provider, {store: store, children: component});
   RWR.reactDOM().render(container, node);
@@ -40,8 +42,8 @@ function _unmountContainerWrapper(config) {
 
 function _mountStoreWrapper (config, options) {
   mountStore(options.name, config.payload)
-  if (options.devtools != false) {
-    renderDevtools(config.node)
+  if (options.include_dev_tools != false) {
+    renderDevtools(options.name, options, config.node)
   }
 }
 

--- a/lib/generators/react_webpack_rails/install_generator.rb
+++ b/lib/generators/react_webpack_rails/install_generator.rb
@@ -17,10 +17,10 @@ module ReactWebpackRails
       template 'react/index.js.erb', 'app/react/index.js'
       create_file 'app/assets/javascripts/react_bundle.js'
       if options.redux
-        copy_file 'react/store/store.js', 'app/react/store/store.js'
+        copy_file 'react/store/configureStore.js', 'app/react/store/configureStore.js'
         copy_file 'react/reducers/index.js', 'app/react/reducers/index.js'
+        copy_file 'react/containers/DevTools.js', 'app/react/containers/DevTools.js'
         create_file 'app/react/actions/.keep'
-        create_file 'app/react/containers/.keep'
       end
       if options.example
         copy_file 'react/components/hello-world.jsx', 'app/react/components/hello-world.jsx'

--- a/lib/generators/react_webpack_rails/install_generator.rb
+++ b/lib/generators/react_webpack_rails/install_generator.rb
@@ -3,7 +3,7 @@ module ReactWebpackRails
     source_root File.expand_path('../templates', __FILE__)
     class_option :example, type: :boolean, default: true, desc: 'Include example component and test files.'
     class_option :router, type: :boolean, default: true, desc: 'Add and expose react-router globally.'
-
+    class_option :redux, type: :boolean, default: false, desc: 'Add redux with directory structure.'
 
     def generate_layout
       copy_file '.babelrc', '.babelrc'
@@ -16,6 +16,12 @@ module ReactWebpackRails
       copy_file 'partial/_react_hot_assets.html.erb', 'app/views/layouts/_react_hot_assets.html.erb'
       template 'react/index.js.erb', 'app/react/index.js'
       create_file 'app/assets/javascripts/react_bundle.js'
+      if options.redux
+        copy_file 'react/store/store.js', 'app/react/store/store.js'
+        copy_file 'react/reducers/index.js', 'app/react/reducers/index.js'
+        create_file 'app/react/actions/.keep'
+        create_file 'app/react/containers/.keep'
+      end
       if options.example
         copy_file 'react/components/hello-world.jsx', 'app/react/components/hello-world.jsx'
         copy_file 'react/components/hello-world-test.jsx', 'app/react/components/hello-world-test.jsx'

--- a/lib/generators/react_webpack_rails/templates/package.json.erb
+++ b/lib/generators/react_webpack_rails/templates/package.json.erb
@@ -15,6 +15,7 @@
     "sinon": "^1.17.2",
     "react-hot-loader": "^1.3.0",
     "webpack-dev-server": "^1.12.1",
+<%= options.redux ? '    "redux-devtools": "^2.1.5",' : ''%>
     "webpack-notifier": "^1.2.1"
   },
   "dependencies": {
@@ -25,6 +26,11 @@
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
 <%= options.router ? '    "react-router": "1.0.0-rc3",' : ''%>
+<% if options.redux %>
+    "react-redux": "^4.0.0",
+    "redux": "^3.0.4",
+    "redux-thunk": "^1.0.0",
+<% end %>
     "react-tools": "*",
     "sass-loader": "^3.0.0",
     "webpack": "^1.12.1"

--- a/lib/generators/react_webpack_rails/templates/package.json.erb
+++ b/lib/generators/react_webpack_rails/templates/package.json.erb
@@ -15,7 +15,11 @@
     "sinon": "^1.17.2",
     "react-hot-loader": "^1.3.0",
     "webpack-dev-server": "^1.12.1",
-<%= options.redux ? '    "redux-devtools": "^2.1.5",' : ''%>
+<% if options.redux %>
+    "redux-devtools": "^3.0.1",
+    "redux-devtools-dock-monitor": "^1.0.1",
+    "redux-devtools-log-monitor": "^1.0.1",
+<% end %>
     "webpack-notifier": "^1.2.1"
   },
   "dependencies": {

--- a/lib/generators/react_webpack_rails/templates/react/containers/DevTools.js
+++ b/lib/generators/react_webpack_rails/templates/react/containers/DevTools.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+// Exported from redux-devtools
+import { createDevTools } from 'redux-devtools';
+
+// Monitors are separate packages, and you can make a custom one
+import LogMonitor from 'redux-devtools-log-monitor';
+import DockMonitor from 'redux-devtools-dock-monitor';
+
+// createDevTools takes a monitor and produces a DevTools component
+const DevTools = createDevTools(
+  // Monitors are individually adjustable with props.
+  // Consult their repositories to learn about those props.
+  // Here, we put LogMonitor inside a DockMonitor.
+  <DockMonitor toggleVisibilityKey='ctrl-h'
+               changePositionKey='ctrl-q'>
+    <LogMonitor theme='tomorrow' />
+  </DockMonitor>
+);
+
+export default DevTools;

--- a/lib/generators/react_webpack_rails/templates/react/index.js.erb
+++ b/lib/generators/react_webpack_rails/templates/react/index.js.erb
@@ -1,21 +1,26 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+<% if options.redux %>
+import { Provider } from 'react-redux';
+<% end %>
 window.React = React;
 window.ReactDOM = ReactDOM;
 <% if options.redux %>
 window.Provider = Provider;
-window.DevTools = DevTools;
-window.DebugPanel = DebugPanel;
-window.LogMonitor = LogMonitor;
 
-import Store from './store/store';
-registerStore('Store', Store)
+// default store
+import Store from './store/configureStore';
+RWR.registerStore('Store', Store);
+
+// default DevTools
+import DevTools from './containers/DevTools';
+RWR.registerContainer('DevTools', DevTools);
 <% end %>
 <% if options.example %>
 import HelloWorld from './components/hello-world';
-registerComponent('HelloWorld', HelloWorld);
+RWR.registerComponent('HelloWorld', HelloWorld);
 <% else %>
 // example usage:
 // import HelloWorld from './components/hello-world';
-// registerComponent('HelloWorld', HelloWorld);
+// RWR.registerComponent('HelloWorld', HelloWorld);
 <% end %>

--- a/lib/generators/react_webpack_rails/templates/react/index.js.erb
+++ b/lib/generators/react_webpack_rails/templates/react/index.js.erb
@@ -2,6 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 window.React = React;
 window.ReactDOM = ReactDOM;
+<% if options.redux %>
+window.Provider = Provider;
+window.DevTools = DevTools;
+window.DebugPanel = DebugPanel;
+window.LogMonitor = LogMonitor;
+
+import Store from './store/store';
+registerStore('Store', Store)
+<% end %>
 <% if options.example %>
 import HelloWorld from './components/hello-world';
 registerComponent('HelloWorld', HelloWorld);

--- a/lib/generators/react_webpack_rails/templates/react/reducers/index.js
+++ b/lib/generators/react_webpack_rails/templates/react/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux'
+// import reducer from './reducer'
+
+const rootReducer = combineReducers({
+  // reducer
+})
+
+export default rootReducer

--- a/lib/generators/react_webpack_rails/templates/react/store/configureStore.js
+++ b/lib/generators/react_webpack_rails/templates/react/store/configureStore.js
@@ -1,16 +1,18 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import { devTools, persistState } from 'redux-devtools';
-import rootReducer from '../reducers/index';
+import rootReducer from '../reducers';
+import DevTools from '../containers/DevTools';
 
 const finalCreateStoreDev = compose(
+  // Middleware you want to use in development:
   applyMiddleware(thunkMiddleware),
-  devTools(),
-  persistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
+  // Required! Enable Redux DevTools with the monitors you chose
+  DevTools.instrument()
 )(createStore);
 
 const finalCreateStoreProd = compose(
- applyMiddleware(thunkMiddleware)
+  // Middleware you want to use in production:
+  applyMiddleware(thunkMiddleware)
 )(createStore);
 
 function configureStore(initialState) {

--- a/lib/generators/react_webpack_rails/templates/react/store/store.js
+++ b/lib/generators/react_webpack_rails/templates/react/store/store.js
@@ -1,0 +1,47 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import { devTools, persistState } from 'redux-devtools';
+import rootReducer from '../reducers/index';
+
+const finalCreateStoreDev = compose(
+  applyMiddleware(thunkMiddleware),
+  devTools(),
+  persistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/))
+)(createStore);
+
+const finalCreateStoreProd = compose(
+ applyMiddleware(thunkMiddleware)
+)(createStore);
+
+function configureStore(initialState) {
+  var store
+  if (RWR.RAILS_ENV  == 'development') {
+    store = finalCreateStoreDev(rootReducer, initialState);
+
+    if (module.hot) {
+      // Enable Webpack hot module replacement for reducers
+      module.hot.accept('../reducers', () => {
+        const nextRootReducer = require('../reducers/index');
+        store.replaceReducer(nextRootReducer);
+      });
+    }
+  } else {
+    store = finalCreateStoreProd(rootReducer, initialState);
+  }
+
+  return store;
+}
+
+let instance = null;
+
+export default class Store {
+  constructor(initial) {
+    if (!instance) {
+      instance = this;
+
+      this.store = configureStore(initial)
+    }
+
+    return instance;
+  }
+}

--- a/lib/react_webpack_rails/view_helpers.rb
+++ b/lib/react_webpack_rails/view_helpers.rb
@@ -21,5 +21,13 @@ module ReactWebpackRails
     def react_router(name)
       react_element('react-router', {}, name: name)
     end
+
+    def redux_store(name, props = {})
+      react_element('redux-store', props, name: name)
+    end
+
+    def redux_container(name, options = {})
+      react_element('redux-container', {}, name: name)
+    end
   end
 end

--- a/lib/react_webpack_rails/view_helpers.rb
+++ b/lib/react_webpack_rails/view_helpers.rb
@@ -22,8 +22,8 @@ module ReactWebpackRails
       react_element('react-router', {}, name: name)
     end
 
-    def redux_store(name, props = {})
-      react_element('redux-store', props, name: name)
+    def redux_store(name, props = {}, options = {})
+      react_element('redux-store', props, options.merge(name: name))
     end
 
     def redux_container(name, options = {})


### PR DESCRIPTION
Basic redux integration

Alt makes it simple to share the same store between components mounted at different nodes. 
This integration adds redux_store rails helpers that makes it possible to populate store with data directly from controller.

TODO:

- [x] js side integration
- [x] redux_store helper
- [x] redux_container helper
- [x] readme update
- [ ] update redux devtools