### PR TITLE
Add camelcase conversion to react_webpack_rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## UNRELEASED
+* `config.react.camelize_props = true` will camelize `react_component` prop keys #409
+
 ## 0.0.5 (November 26, 2015)
 * Add Hot Reload support
   * Dependencies:

--- a/lib/react_webpack_rails/railtie.rb
+++ b/lib/react_webpack_rails/railtie.rb
@@ -2,6 +2,10 @@ require 'react_webpack_rails/view_helpers'
 
 module ReactWebpackRails
   class Railtie < ::Rails::Railtie
+    config.react = ActiveSupport::OrderedOptions.new
+    # Sensible defaults. Can be overridden in application.rb
+    config.react.camelize_props = false # pass in an underscored hash but get a camelized hash
+
     initializer 'react_webpack_rails.view_helpers' do
       ActionView::Base.send :include, ViewHelpers
     end

--- a/lib/react_webpack_rails/view_helpers.rb
+++ b/lib/react_webpack_rails/view_helpers.rb
@@ -3,6 +3,7 @@ module ReactWebpackRails
     # based on https://github.com/reactjs/react-rails/blob/master/lib/react/rails/view_helper.rb
     def react_element(integration_name, payload = {}, options = {}, &block)
       html_options = { data: {} }
+      payload = camelize_props_key(payload) if Rails.application.config.react.camelize_props
       html_options[:data].tap do |data|
         data[:integration_name] = integration_name
         data[:options] = options.except(:tag)
@@ -20,6 +21,14 @@ module ReactWebpackRails
 
     def react_router(name)
       react_element('react-router', {}, name: name)
+    end
+
+    private
+    def camelize_props_key(props)
+      return props unless props.is_a?(Hash)
+      props.inject({}) do |h, (k,v)|
+        h[k.to_s.camelize(:lower)] = v.is_a?(Hash) ? camelize_props_key(v) : v; h
+      end
     end
   end
 end


### PR DESCRIPTION
This is a port of reactjs/react-rails#409

Not a huge deal, but makes it easier to deal with the difference in naming conventions between Ruby and JS.