### PR TITLE
react_element helper fix

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -81,15 +81,16 @@
   * ### react_component [ruby]
 
     ```ruby
-    react_component(String component_name[, Object props])
+    react_component(String component_name[, Object props, Object options, Object html_options])
     ```
 
     Creates DOM node with props as data attributes in rendered view so RWR can grab it and mount proper component.
+    Options are passed down to react while html_options are passed to element created by helper.
 
     ##### example:
 
     ```ruby
-    <%= react_component('MyComponentName', MySerializer.new(my_data)) %>
+    <%= react_component('MyComponentName', MySerializer.new(my_data), {}, {tag: :ul, class: 'my-class'}) %>
     ```
 
     **note:** Props Object will be parsed to JSON. Be careful when passing rails models there - all its data accessible after `.to_json` will be exposed as data-attributes. We  recommend using serializers to control it.

--- a/lib/react_webpack_rails/view_helpers.rb
+++ b/lib/react_webpack_rails/view_helpers.rb
@@ -1,22 +1,20 @@
 module ReactWebpackRails
   module ViewHelpers
-    # based on https://github.com/reactjs/react-rails/blob/master/lib/react/rails/view_helper.rb
-    def react_element(integration_name, payload = {}, options = {}, &block)
-      html_options = { data: {} }
+    def react_element(integration_name, payload = {}, options = {}, html_options = {}, &block)
       payload = camelize_props_key(payload) if Rails.application.config.react.camelize_props
-      html_options[:data].tap do |data|
-        data[:integration_name] = integration_name
-        data[:options] = options.except(:tag)
-        data[:payload] = (payload.is_a?(String) ? payload : payload.to_json)
-        data[:react_element] = true
-      end
-      html_tag = options[:tag] || :div
-
+      data = {
+        integration_name: integration_name,
+        options: options,
+        payload: (payload.is_a?(String) ? payload : payload.to_json),
+        react_element: true
+      }
+      html_options = html_options.merge(data: data)
+      html_tag = html_options.delete(:tag) || :div
       content_tag(html_tag, '', html_options, &block)
     end
 
-    def react_component(name, props = {}, options = {})
-      react_element('react-component', props, options.merge(name: name))
+    def react_component(name, props = {}, options = {}, html_options = {})
+      react_element('react-component', props, options.merge(name: name), html_options)
     end
 
     def react_router(name)
@@ -24,9 +22,10 @@ module ReactWebpackRails
     end
 
     private
+
     def camelize_props_key(props)
       return props unless props.is_a?(Hash)
-      props.inject({}) do |h, (k,v)|
+      props.each_with_object({}) do |h, (k, v)|
         h[k.to_s.camelize(:lower)] = v.is_a?(Hash) ? camelize_props_key(v) : v; h
       end
     end

--- a/spec/rails3_dummy_app/.gitignore
+++ b/spec/rails3_dummy_app/.gitignore
@@ -17,4 +17,4 @@
 /tmp
 
 /node_modules
-/spec/rails3_dummy_app/app/assets/javascripts/react_bundle.js
+/app/assets/javascripts/react_bundle.js

--- a/spec/rails3_dummy_app/spec/helpers/react_webpack_rails/view_helpers_spec.rb
+++ b/spec/rails3_dummy_app/spec/helpers/react_webpack_rails/view_helpers_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ReactWebpackRails::ViewHelpers, type: :helper do
     end
 
     context 'when options with tag given' do
-      subject { helper.react_element('react-component', {}, {foo: :bar, tag: :li}) }
+      subject { helper.react_element('react-component', {}, {foo: :bar}, {tag: :li}) }
       it 'is renders passed tag' do
         expect(subject).to include('<li ', '></li>')
       end
@@ -58,7 +58,7 @@ RSpec.describe ReactWebpackRails::ViewHelpers, type: :helper do
     it 'wraps #react_component with proper options' do
       expect(helper)
         .to receive(:react_element)
-        .with('react-component', { foo: 'bar' }, name: 'Todo')
+        .with('react-component', { foo: 'bar' }, {name: 'Todo'}, {})
         .once
       helper.react_component('Todo', foo: 'bar')
     end
@@ -67,7 +67,7 @@ RSpec.describe ReactWebpackRails::ViewHelpers, type: :helper do
       subject { helper.react_component('Todo') }
 
       it 'sets an empty object as default' do
-        expect(helper).to receive(:react_element).with('react-component', {}, name: 'Todo').once
+        expect(helper).to receive(:react_element).with('react-component', {}, {name: 'Todo'}, {}).once
         helper.react_component('Todo')
       end
     end

--- a/spec/rails4_dummy_app/.gitignore
+++ b/spec/rails4_dummy_app/.gitignore
@@ -17,4 +17,4 @@
 /tmp
 
 /node_modules
-/spec/rails4_dummy_app/app/assets/javascripts/react_bundle.js
+/app/assets/javascripts/react_bundle.js

--- a/spec/rails4_dummy_app/spec/helpers/react_webpack_rails/view_helpers_spec.rb
+++ b/spec/rails4_dummy_app/spec/helpers/react_webpack_rails/view_helpers_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ReactWebpackRails::ViewHelpers, type: :helper do
     end
 
     context 'when options with tag given' do
-      subject { helper.react_element('react-component', {}, {foo: :bar, tag: :li}) }
+      subject { helper.react_element('react-component', {}, {foo: :bar}, {tag: :li}) }
       it 'is renders passed tag' do
         expect(subject).to include('<li ', '></li>')
       end
@@ -58,7 +58,7 @@ RSpec.describe ReactWebpackRails::ViewHelpers, type: :helper do
     it 'wraps #react_component with proper options' do
       expect(helper)
         .to receive(:react_element)
-        .with('react-component', { foo: 'bar' }, name: 'Todo')
+        .with('react-component', { foo: 'bar' }, {name: 'Todo'}, {})
         .once
       helper.react_component('Todo', foo: 'bar')
     end
@@ -67,7 +67,7 @@ RSpec.describe ReactWebpackRails::ViewHelpers, type: :helper do
       subject { helper.react_component('Todo') }
 
       it 'sets an empty object as default' do
-        expect(helper).to receive(:react_element).with('react-component', {}, name: 'Todo').once
+        expect(helper).to receive(:react_element).with('react-component', {}, {name: 'Todo'}, {}).once
         helper.react_component('Todo')
       end
     end


### PR DESCRIPTION
Allow passing html_options to content tag so it's possible to choose tag, class, style etc of generated by helper element. Keep options and pass them down to RWR