### PR TITLE
Feature/create camelize service

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ namespace :test do
 
   desc 'Run gem tests'
   task :gem do
-    sh %Q(bundle exec rspec spec/react_webpack_rails_spec.rb)
+    sh %Q(bundle exec rspec spec/react_webpack_rails_spec.rb spec/react_webpack_rails)
   end
 
   desc 'Run rspec for rails3 application'

--- a/lib/react_webpack_rails.rb
+++ b/lib/react_webpack_rails.rb
@@ -6,4 +6,5 @@ if defined?(Rails)
   require 'react_webpack_rails/node_integration_runner'
   require 'react_webpack_rails/errors/base'
   require 'react_webpack_rails/errors/node_failure'
+  require 'react_webpack_rails/services'
 end

--- a/lib/react_webpack_rails/services.rb
+++ b/lib/react_webpack_rails/services.rb
@@ -1,0 +1,1 @@
+require 'react_webpack_rails/services/camelize_keys'

--- a/lib/react_webpack_rails/services/camelize_keys.rb
+++ b/lib/react_webpack_rails/services/camelize_keys.rb
@@ -1,0 +1,13 @@
+module ReactWebpackRails
+  module Services
+    class CamelizeKeys
+      def self.call(props)
+        return props unless props.is_a?(Hash)
+        props.inject({}) do |h, (k, v)|
+          h[k.to_s.camelize(:lower)] = v.is_a?(Hash) ? camelize_props_key(v) : v
+          h
+        end
+      end
+    end
+  end
+end

--- a/lib/react_webpack_rails/view_helpers.rb
+++ b/lib/react_webpack_rails/view_helpers.rb
@@ -1,3 +1,5 @@
+require_relative 'services/camelize_keys'
+
 module ReactWebpackRails
   module ViewHelpers
     def react_element(integration_name, payload = {}, html_options = {}, &block)
@@ -13,7 +15,7 @@ module ReactWebpackRails
 
     def react_component(name, raw_props = {}, options = {})
       props = raw_props.as_json
-      props = camelize_props_key(props) if Rails.application.config.react.camelize_props
+      props = Services::CamelizeKeys.call(props) if Rails.application.config.react.camelize_props
       if server_side(options.delete(:server_side))
         result = NodeIntegrationRunner.new('react-component', props: props, name: name).run
         react_element('react-component', { props: props, name: name }, options) do
@@ -29,14 +31,6 @@ module ReactWebpackRails
     end
 
     private
-
-    def camelize_props_key(props)
-      return props unless props.is_a?(Hash)
-      props.inject({}) do |h, (k, v)|
-        h[k.to_s.camelize(:lower)] = v.is_a?(Hash) ? camelize_props_key(v) : v
-        h
-      end
-    end
 
     def server_side(server_side)
       server_side.nil? ? Rails.application.config.react.server_side : server_side

--- a/spec/react_webpack_rails/services/camelize_keys_spec.rb
+++ b/spec/react_webpack_rails/services/camelize_keys_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'react_webpack_rails/services/camelize_keys'
+require 'active_support/core_ext/string'
+
+describe ReactWebpackRails::Services::CamelizeKeys do
+  describe '.call' do
+    context 'when props object is an array' do
+      let(:props) { ['some', 'props'] }
+
+      it { expect(described_class.call(props)).to eq(props) }
+    end
+
+    context 'when props object is a hash' do
+      let(:props) { { props_name: 'name', props_value: 'value' } }
+      let(:camelized_props) { { 'propsName' => 'name', 'propsValue' => 'value' } }
+
+      it { expect(described_class.call(props)).to eq(camelized_props) }
+    end
+  end
+end


### PR DESCRIPTION
This changes allows to use camelize_keys service in plugins, for example, rwr-redux.