### PR TITLE
Update to React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
   },
   "homepage": "https://github.com/netguru/react_webpack_rails#readme",
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "dependencies": {
-    "babel-polyfill": "^6.3.0"
+    "babel-polyfill": "^6.3.0",
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",


### PR DESCRIPTION
React 15 came out yesterday, and it has some nice improvements.

This PR updates the peer dependencies of the contained `react-webpack-rails` npm package to require 15.0 - otherwise one can't use a newer React version unfortunately.

Tests are green.