### PR TITLE
Implement registering components via object

### DIFF
--- a/js/src/integrations/react.js
+++ b/js/src/integrations/react.js
@@ -13,7 +13,13 @@ class ReactIntegration {
     this.renderComponentToString = this.renderComponentToString.bind(this);
   }
 
-  registerComponent(name, component) {
+  registerComponent(...args) {
+    if (typeof args[0] === 'object') {
+      const component = args[0];
+      this.components = Object.assign({}, this.components, component);
+    }
+
+    const [name, component] = args;
     this.components[name] = component;
   }
 

--- a/js/test/integrations/react.spec.js
+++ b/js/test/integrations/react.spec.js
@@ -27,9 +27,14 @@ describe('ReactIntegration', function () {
   });
 
   describe('#registerComponent', function () {
-    it('adds component to the components storage', function () {
+    it('registers component using separate args', function () {
       subject.registerComponent('HelloWorld', HelloComponent);
       expect(subject.components.HelloWorld).toBe(HelloComponent);
+    });
+
+    it('registers component using Object', function () {
+      subject.registerComponent({ HelloComponent });
+      expect(subject.components.HelloComponent).toBe(HelloComponent);
     });
   });
 


### PR DESCRIPTION
This resolves: #114 :)

Now you can register component two ways:

```jsx
import RWR from 'react-webpack-rails'
import FileInput from './components/FileInput';

RWR.run();
RWR.registerComponent('FileInput', FileInput);
```

AND

```jsx
import RWR from 'react-webpack-rails'
import FileInput from './components/FileInput';

RWR.run();
RWR.registerComponent({ FileInput });
```