### PR TITLE
Implement registering multiple components at once via object

### DIFF
--- a/js/src/integrations/react.js
+++ b/js/src/integrations/react.js
@@ -17,6 +17,10 @@ class ReactIntegration {
     this.components[name] = component;
   }
 
+  registerComponents(components) {
+    this.components = Object.assign({}, this.components, components);
+  }
+
   getComponent(name) {
     return this.components[name];
   }

--- a/js/test/integrations/react.spec.js
+++ b/js/test/integrations/react.spec.js
@@ -15,6 +15,18 @@ class HelloComponent extends React.Component {
   }
 }
 
+class FooComponent extends React.Component {
+  static propTypes() {
+    return {
+      username: PropTypes.string.isRequired,
+    };
+  }
+
+  render() {
+    return (<div>Foo! Bar!</div>);
+  }
+}
+
 describe('ReactIntegration', function () {
   afterEach(function () {
     subject.components = {};
@@ -30,6 +42,14 @@ describe('ReactIntegration', function () {
     it('adds component to the components storage', function () {
       subject.registerComponent('HelloWorld', HelloComponent);
       expect(subject.components.HelloWorld).toBe(HelloComponent);
+    });
+  });
+
+  describe('#registerComponents', function () {
+    it('adds multiple components', function () {
+      subject.registerComponents({ HelloComponent, FooComponent });
+      expect(subject.components.HelloComponent).toBe(HelloComponent);
+      expect(subject.components.FooComponent).toBe(FooComponent);
     });
   });
 


### PR DESCRIPTION
This resolves: #113 :)

Now you can register multiple components at once:

```jsx
import RWR from 'react-webpack-rails'
import FileInput from './components/FileInput';
import SelectInput from './components/SelectInput';

RWR.run();
RWR.registerComponents({ FileInput, SelectInput });
```
