### PR TITLE
Allow setting port via env variable

### DIFF
--- a/lib/generators/react_webpack_rails/templates/react/node_server.js
+++ b/lib/generators/react_webpack_rails/templates/react/node_server.js
@@ -8,7 +8,7 @@ const httpdispatcher = require('httpdispatcher');
 const dispatcher = new httpdispatcher();
 const { integrationsManager } = require('react-webpack-rails');
 
-const PORT = 8081;
+const PORT = parseInt(process.env.PORT || 8081);
 const ASSETS_MAPPING_PATH = 'tmp/cache/assets-mapping.json';
 
 global.__RWR_ENV__ = {};


### PR DESCRIPTION
Setting the PORT env variable will control the port the server starts on. Helpful when running with foreman.