### PR TITLE
WIP: react-hot-loader v3 migration

### DIFF
--- a/docs/hot_reloading.md
+++ b/docs/hot_reloading.md
@@ -1,0 +1,43 @@
+# Hot reloading
+
+## Migration to react-hot-loader v3
+
+RWR is now using react-hot-loader v3 instead of v1 (https://github.com/netguru/react_webpack_rails/pull/143)
+
+V3 is a complete overhaul which fixes many problems with previous version, i.e. reloading functional components.
+
+The upgrade requires a few steps which can be applied automatically via our generator:
+
+```
+bundle exec rails generate react_webpack_rails:install:hot_reload
+```
+
+
+Detailed steps are outlined below:
+
+1. Bump `react-hot-loader` version in `package.json` file
+
+```
+"react-hot-loader": "^3.0.0-beta.6"
+```
+
+2. Replace react-hot with `react-hot-loader/webpack` in `webpack/hot-dev.config.js` file
+
+```javascript
+jsxLoader.loaders.unshift('react-hot-loader/webpack');
+```
+
+3. Add `react-hot-loader/patch` in `webpack/hot-dev.config.js` file
+
+```javascript
+config.entry.main.unshift('react-hot-loader/patch')
+```
+
+4. Add following code at the bottom of your `app/react/index.js` file to enable hot-reloading:
+
+```javascript
+if (module.hot) {
+  module.hot.accept();
+  RWR.reloadNodes();
+}
+```

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -21,6 +21,7 @@ class RWR {
 
     this.mountNodes = nodes.mountNodes;
     this.unmountNodes = nodes.unmountNodes;
+    this.reloadNodes = nodes.reloadNodes;
   }
 
   run() {

--- a/js/src/integrations/react.js
+++ b/js/src/integrations/react.js
@@ -40,6 +40,7 @@ class ReactIntegration {
 
   renderComponent(name, props, node) {
     const component = this.createComponent(name, props);
+    this._attachIntegrationData(node, name, props);
     ReactDOM.render(component, node);
   }
 
@@ -67,6 +68,15 @@ class ReactIntegration {
       }.bind(this),
     };
   }
+
+  _attachIntegrationData(node, name, props) {
+    const nativeNode = node.selector ? node[0] : node; // normalize jquery objects to native nodes
+    const dataset = nativeNode.dataset;
+    if (dataset.rwrElement) return;
+    dataset.rwrElement = 'true';
+    dataset.integrationName = 'react-component';
+    dataset.payload = JSON.stringify({ name, props });
+  };
 }
 
 export default new ReactIntegration;

--- a/js/src/integrations/react.js
+++ b/js/src/integrations/react.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
+import { AppContainer } from 'react-hot-loader';
 
 class ReactIntegration {
   constructor() {
@@ -33,7 +34,8 @@ class ReactIntegration {
 
   createComponent(name, props) {
     const constructor = this.getComponent(name);
-    return React.createElement(constructor, props);
+    const element = React.createElement(constructor, props);
+    return React.createElement(AppContainer, null, element);
   }
 
   renderComponent(name, props, node) {

--- a/js/src/nodes.js
+++ b/js/src/nodes.js
@@ -34,18 +34,23 @@ function _unmountNode(node) {
   if (typeof(unmount) === 'function') { unmount(node, data.payload); }
 }
 
-export default {
-  mountNodes: function _mountNodes(searchSelector) {
-    const nodes = _findDOMNodes(searchSelector);
-    for (let i = 0; i < nodes.length; ++i) {
-      _mountNode(nodes[i]);
-    }
-  },
+function mountNodes(searchSelector) {
+  const nodes = _findDOMNodes(searchSelector);
+  for (let i = 0; i < nodes.length; ++i) {
+    _mountNode(nodes[i]);
+  }
+}
 
-  unmountNodes: function _unmountNodes(searchSelector) {
-    const nodes = _findDOMNodes(searchSelector);
-    for (let i = 0; i < nodes.length; ++i) {
-      _unmountNode(nodes[i]);
-    }
-  },
+function unmountNodes(searchSelector) {
+  const nodes = _findDOMNodes(searchSelector);
+  for (let i = 0; i < nodes.length; ++i) {
+    _unmountNode(nodes[i]);
+  }
+}
+
+export default {
+  mountNodes,
+  unmountNodes,
+  // Used after hot module replacement
+  reloadNodes: mountNodes,
 };

--- a/js/test/integrations/react.spec.js
+++ b/js/test/integrations/react.spec.js
@@ -94,6 +94,18 @@ describe('ReactIntegration', function () {
     });
   });
 
+  describe('#renderComponent', function () {
+    it('attaches integration data to node', function () {
+      const node = { nodeType: 1, nodeName: 'DIV', dataset: {} };
+      const props = { key: 1 };
+      const reactSpy = spyOn(ReactDOM, 'render');
+      subject.renderComponent('componentName', props, node);
+      expect(node.dataset.rwrElement).toEqual('true');
+      expect(node.dataset.integrationName).toEqual('react-component');
+      expect(node.dataset.payload).toEqual('{"name":"componentName","props":{"key":1}}');
+    });
+  });
+
   describe('#integrationWrapper', function () {
     const node = { nodeType: 1, nodeName: 'DIV' };
 

--- a/js/test/integrations/react.spec.js
+++ b/js/test/integrations/react.spec.js
@@ -1,6 +1,7 @@
 import expect, { spyOn } from 'expect';
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
+import { AppContainer } from 'react-hot-loader';
 import subject from '../../src/integrations/react';
 
 class HelloComponent extends React.Component {
@@ -70,10 +71,13 @@ describe('ReactIntegration', function () {
   });
 
   describe('#createComponent', function () {
-    it('creates component with given props', function () {
+    it('creates component with given props wrapped in AppContainer for hot-reloading', function () {
       subject.registerComponent('HelloWorld', HelloComponent);
-      const component = subject.createComponent('HelloWorld', { username: 'testUser' });
+      const wrapper = subject.createComponent('HelloWorld', { username: 'testUser' });
 
+      expect(wrapper.type).toBe(AppContainer);
+
+      const component = wrapper.props.children;
       expect(component.props).toEqual({ username: 'testUser' });
       expect(component.type).toBe(HelloComponent);
     });

--- a/js/test/nodes.spec.js
+++ b/js/test/nodes.spec.js
@@ -2,7 +2,7 @@ import expect, { spyOn, createSpy } from 'expect';
 import Nodes from '../src/nodes';
 import IntegrationsManager from '../src/integrations-manager';
 
-const { mountNodes, unmountNodes } = Nodes;
+const { mountNodes, unmountNodes, reloadNodes } = Nodes;
 
 const node = {
   nodeType: 1,
@@ -116,6 +116,12 @@ describe('Nodes', function () {
         expect(documentSpy.calls.length).toEqual(1);
         expect(documentSpy).toHaveBeenCalledWith('[selectorsWithNodes]');
       });
+    });
+  });
+
+  describe('#reloadNodes', function () {
+    it('is equal to mountNodes', function () {
+      expect(reloadNodes).toEqual(mountNodes);
     });
   });
 });

--- a/lib/generators/react_webpack_rails/install/hot_reload_generator.rb
+++ b/lib/generators/react_webpack_rails/install/hot_reload_generator.rb
@@ -42,7 +42,7 @@ module ReactWebpackRails
 
           if (module.hot) {
             module.hot.accept();
-            RWR.mountNodes();
+            RWR.reloadNodes();
           }
           JS
         end

--- a/lib/generators/react_webpack_rails/install/hot_reload_generator.rb
+++ b/lib/generators/react_webpack_rails/install/hot_reload_generator.rb
@@ -37,6 +37,17 @@ module ReactWebpackRails
         inject_into_file settings[:layout_file], settings[:parsed_command], after: "#{settings[:body_tag]}\n"
       end
 
+      def index
+        append_to_file 'app/react/index.js' do <<-'JS'.strip_heredoc
+
+          if (module.hot) {
+            module.hot.accept();
+            RWR.mountNodes();
+          }
+          JS
+        end
+      end
+
       private
 
       def template_language_settings(command)

--- a/lib/generators/react_webpack_rails/templates/packages/hot-reload.json
+++ b/lib/generators/react_webpack_rails/templates/packages/hot-reload.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^3.0.0-beta.6",
     "webpack-dev-server": "^1.14.0"
   },
   "scripts": {

--- a/lib/generators/react_webpack_rails/templates/webpack/hot-dev.config.js
+++ b/lib/generators/react_webpack_rails/templates/webpack/hot-dev.config.js
@@ -1,7 +1,7 @@
 var config = require('./dev.config');
 
 var jsxLoader = config.module.loaders.filter(function(loader) { return loader.key == 'jsx' })[0]
-jsxLoader.loaders.unshift('react-hot');
+jsxLoader.loaders.unshift('react-hot-loader/webpack');
 
 var scssLoader = config.module.loaders.filter(function(loader) { return loader.key == 'style' })[0]
 scssLoader.loader = 'style!css!sass!';
@@ -12,5 +12,7 @@ config.entry.main.push(
   'webpack/hot/only-dev-server',
   'webpack-dev-server/client?http://localhost:8080'
 )
+
+config.entry.main.unshift('react-hot-loader/patch')
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "babel-polyfill": "^6.3.0",
     "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react-dom": "^15.0.0",
+    "react-hot-loader": "^3.0.0-beta.6"
   },
   "devDependencies": {
     "babel-cli": "^6.10.0",

--- a/spec/rails3_dummy_app/app/react/index.js
+++ b/spec/rails3_dummy_app/app/react/index.js
@@ -4,3 +4,8 @@ RWR.run();
 import HelloWorld from './components/hello-world';
 RWR.registerComponent('HelloWorld', HelloWorld);
 
+
+if (module.hot) {
+  module.hot.accept();
+  RWR.mountNodes();
+}

--- a/spec/rails3_dummy_app/app/react/index.js
+++ b/spec/rails3_dummy_app/app/react/index.js
@@ -7,5 +7,5 @@ RWR.registerComponent('HelloWorld', HelloWorld);
 
 if (module.hot) {
   module.hot.accept();
-  RWR.mountNodes();
+  RWR.reloadNodes();
 }

--- a/spec/rails3_dummy_app/package.json
+++ b/spec/rails3_dummy_app/package.json
@@ -12,7 +12,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "mocha": "^3.2.0",
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^3.0.0-beta.6",
     "sinon": "^1.17.0",
     "webpack-dev-server": "^1.14.0",
     "webpack-notifier": "^1.3.0"

--- a/spec/rails3_dummy_app/webpack/hot-dev.config.js
+++ b/spec/rails3_dummy_app/webpack/hot-dev.config.js
@@ -1,7 +1,7 @@
 var config = require('./dev.config');
 
 var jsxLoader = config.module.loaders.filter(function(loader) { return loader.key == 'jsx' })[0]
-jsxLoader.loaders.unshift('react-hot');
+jsxLoader.loaders.unshift('react-hot-loader/webpack');
 
 var scssLoader = config.module.loaders.filter(function(loader) { return loader.key == 'style' })[0]
 scssLoader.loader = 'style!css!sass!';
@@ -12,5 +12,7 @@ config.entry.main.push(
   'webpack/hot/only-dev-server',
   'webpack-dev-server/client?http://localhost:8080'
 )
+
+config.entry.main.unshift('react-hot-loader/patch')
 
 module.exports = config;

--- a/spec/rails4_dummy_app/app/react/index.js
+++ b/spec/rails4_dummy_app/app/react/index.js
@@ -4,3 +4,8 @@ RWR.run();
 import HelloWorld from './components/hello-world';
 RWR.registerComponent('HelloWorld', HelloWorld);
 
+
+if (module.hot) {
+  module.hot.accept();
+  RWR.mountNodes();
+}

--- a/spec/rails4_dummy_app/app/react/index.js
+++ b/spec/rails4_dummy_app/app/react/index.js
@@ -7,5 +7,5 @@ RWR.registerComponent('HelloWorld', HelloWorld);
 
 if (module.hot) {
   module.hot.accept();
-  RWR.mountNodes();
+  RWR.reloadNodes();
 }

--- a/spec/rails4_dummy_app/package.json
+++ b/spec/rails4_dummy_app/package.json
@@ -12,7 +12,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "mocha": "^3.2.0",
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^3.0.0-beta.6",
     "sinon": "^1.17.0",
     "webpack-dev-server": "^1.14.0",
     "webpack-notifier": "^1.3.0"

--- a/spec/rails4_dummy_app/webpack/hot-dev.config.js
+++ b/spec/rails4_dummy_app/webpack/hot-dev.config.js
@@ -1,7 +1,7 @@
 var config = require('./dev.config');
 
 var jsxLoader = config.module.loaders.filter(function(loader) { return loader.key == 'jsx' })[0]
-jsxLoader.loaders.unshift('react-hot');
+jsxLoader.loaders.unshift('react-hot-loader/webpack');
 
 var scssLoader = config.module.loaders.filter(function(loader) { return loader.key == 'style' })[0]
 scssLoader.loader = 'style!css!sass!';
@@ -12,5 +12,7 @@ config.entry.main.push(
   'webpack/hot/only-dev-server',
   'webpack-dev-server/client?http://localhost:8080'
 )
+
+config.entry.main.unshift('react-hot-loader/patch')
 
 module.exports = config;

--- a/spec/rails5_dummy_app/app/controllers/pages_controller.rb
+++ b/spec/rails5_dummy_app/app/controllers/pages_controller.rb
@@ -1,12 +1,16 @@
 class PagesController < ApplicationController
-  def client_side_hello_world
-    @name = 'username'
-  end
-
-  def react_component_renderer_test
-    render react_component: 'HelloWorld', props: { name: 'render component test' }
-  end
-
   def home
+  end
+
+  def server_controller_component
+    render react_component: 'HelloWorld', props: { name: 'server controller' }
+  end
+
+  def server_view_component
+    @name = 'server view'
+  end
+
+  def client_component
+    @name = 'client'
   end
 end

--- a/spec/rails5_dummy_app/app/react/components/button.jsx
+++ b/spec/rails5_dummy_app/app/react/components/button.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default ({ onClick, children }) => (
+  <button
+    type="button"
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);

--- a/spec/rails5_dummy_app/app/react/components/counter.jsx
+++ b/spec/rails5_dummy_app/app/react/components/counter.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Button from './button';
+
+class Counter extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { count: 0 };
+  }
+
+  componentWillMount() {
+    console.log("Counter will mount");
+  }
+
+  componentDidMount() {
+    console.log("Counter did mount");
+  }
+
+  render() {
+    const { count } = this.state;
+    const addOne = () =>
+      this.setState({ count: count + 1 });
+    return (
+      <div>
+        Current count:&nbsp;
+        {count}
+        <br />
+        <Button onClick={addOne}>
+          add
+        </Button>
+      </div>
+    );
+  }
+}
+
+export default Counter;

--- a/spec/rails5_dummy_app/app/react/index.js
+++ b/spec/rails5_dummy_app/app/react/index.js
@@ -4,3 +4,10 @@ RWR.run();
 import HelloWorld from './components/hello-world';
 RWR.registerComponent('HelloWorld', HelloWorld);
 
+import Counter from './components/counter';
+RWR.registerComponent('Counter', Counter);
+
+if (module.hot) {
+  module.hot.accept();
+  RWR.mountNodes();
+}

--- a/spec/rails5_dummy_app/app/react/index.js
+++ b/spec/rails5_dummy_app/app/react/index.js
@@ -9,5 +9,5 @@ RWR.registerComponent('Counter', Counter);
 
 if (module.hot) {
   module.hot.accept();
-  RWR.mountNodes();
+  RWR.reloadNodes();
 }

--- a/spec/rails5_dummy_app/app/views/pages/client_component.html.erb
+++ b/spec/rails5_dummy_app/app/views/pages/client_component.html.erb
@@ -1,0 +1,5 @@
+<div id="root"></div>
+<script>
+  const element = document.getElementById('root');
+  RWR.renderComponent('HelloWorld', { name: "client" }, element);
+</script>

--- a/spec/rails5_dummy_app/app/views/pages/client_counter_component.html.erb
+++ b/spec/rails5_dummy_app/app/views/pages/client_counter_component.html.erb
@@ -1,0 +1,5 @@
+<div id="root"></div>
+<script>
+  const element = document.getElementById('root');
+  RWR.renderComponent('Counter', {}, element);
+</script>

--- a/spec/rails5_dummy_app/app/views/pages/home.html.erb
+++ b/spec/rails5_dummy_app/app/views/pages/home.html.erb
@@ -1,2 +1,8 @@
-<%= link_to 'component test', react_component_renderer_test_path %>
 Rails 5 dummy app
+
+<ul>
+  <li><%= link_to 'server controller component test', server_controller_component_path %></li>
+  <li><%= link_to 'server view component test', server_view_component_path %></li>
+  <li><%= link_to 'client test', client_component_path %></li>
+  <li><%= link_to 'counter test', client_counter_component_path %></li>
+</ul>

--- a/spec/rails5_dummy_app/app/views/pages/server_view_component.html.erb
+++ b/spec/rails5_dummy_app/app/views/pages/server_view_component.html.erb
@@ -1,0 +1,1 @@
+<%= react_component('HelloWorld', { name: @name }, { server_side: true }) %>

--- a/spec/rails5_dummy_app/config/routes.rb
+++ b/spec/rails5_dummy_app/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   get 'react_examples/component', to: 'react_examples#component', as: :component
-  get 'react_component_renderer_test', to: 'pages#react_component_renderer_test', as: :react_component_renderer_test
+  get 'server_controller_component', to: 'pages#server_controller_component', as: :server_controller_component
+  get 'server_view_component', to: 'pages#server_view_component', as: :server_view_component
+  get 'client_component', to: 'pages#client_component', as: :client_component
+  get 'client_counter_component', to: 'pages#client_counter_component', as: :client_counter_component
   root to: 'pages#home'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 

--- a/spec/rails5_dummy_app/package.json
+++ b/spec/rails5_dummy_app/package.json
@@ -12,7 +12,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "mocha": "^3.2.0",
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^3.0.0-beta.6",
     "sinon": "^1.17.0",
     "webpack-dev-server": "^1.14.0",
     "webpack-notifier": "^1.3.0"

--- a/spec/rails5_dummy_app/spec/features/react_component_render_spec.rb
+++ b/spec/rails5_dummy_app/spec/features/react_component_render_spec.rb
@@ -7,7 +7,7 @@ feature 'client_side_hello_world page', js: true do
 
   it 'renders react component with attribute from Rails controller' do
     expect(page).to have_content('Rails 5 dummy app')
-    visit(react_component_renderer_test_path)
-    expect(page).to have_content('Hello World render component test')
+    visit(server_controller_component_path)
+    expect(page).to have_content('Hello World server controller')
   end
 end

--- a/spec/rails5_dummy_app/webpack/hot-dev.config.js
+++ b/spec/rails5_dummy_app/webpack/hot-dev.config.js
@@ -1,7 +1,7 @@
 var config = require('./dev.config');
 
 var jsxLoader = config.module.loaders.filter(function(loader) { return loader.key == 'jsx' })[0]
-jsxLoader.loaders.unshift('react-hot');
+jsxLoader.loaders.unshift('react-hot-loader/webpack');
 
 var scssLoader = config.module.loaders.filter(function(loader) { return loader.key == 'style' })[0]
 scssLoader.loader = 'style!css!sass!';
@@ -12,5 +12,7 @@ config.entry.main.push(
   'webpack/hot/only-dev-server',
   'webpack-dev-server/client?http://localhost:8080'
 )
+
+config.entry.main.unshift('react-hot-loader/patch')
 
 module.exports = config;


### PR DESCRIPTION
# React Hot Loader v3 migration

https://github.com/gaearon/react-hot-loader

react-hot-loader is a complete overhaul which fixes many problems with previous version, i.e. reloading functional components. RWR should upgrade to use latest-and greatest version (3) (currently it uses v1)

## TODO
- [x] Bump `react-hot-loader` version in `package.json`
- [x] Add setup code required by v3
  - [x] replace `react-hot` with `react-hot-loader/webpack` in webpack config
  - [x] add `react-hot-loader/patch` to main entrypoint in webpack
- [x] Wrap every root component rendered by RWR with `AppContainer` for hot-reloading
- [x] Accept hot reloading changes with `module.hot` hooks and re-render mounted RWR components
  - [x] reload controller-rendered components (`react_component` helper)
  - [x] reload view-rendered components (`render react_component: `)
  - [x] reload client-rendered components (`RWR.renderComponent`)
- [x] Update test apps in `spec/rails*_dummy_app` directories
- [x] Add migration guide

#141 