### PR TITLE
Add missing net/http library requirement

### DIFF
--- a/lib/react_webpack_rails/node_integration_runner.rb
+++ b/lib/react_webpack_rails/node_integration_runner.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module ReactWebpackRails
   class NodeIntegrationRunner
     include NodeHelpers


### PR DESCRIPTION
I have faced the problem with `run` method because gem doesn't recognize the Net library. Finally get error:
```NameError: uninitialized constant ReactWebpackRails::NodeIntegrationRunner::Net```

Rails: 5.0.2
Ruby: 2.4.0